### PR TITLE
Upgrade gradle to 6.6.1, upgrade dependencies.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,10 +8,10 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.6.1")
+        classpath("com.android.tools.build:gradle:4.2.0-alpha13")
         classpath("org.jlleitschuh.gradle:ktlint-gradle:9.2.1")
         classpath("com.github.dcendents:android-maven-gradle-plugin:2.1")
-        classpath(kotlin("gradle-plugin", version = "1.3.71"))
+        classpath(kotlin("gradle-plugin", version = "1.4.10"))
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -7,11 +7,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion(29)
+    compileSdkVersion(30)
     defaultConfig {
         applicationId = "com.commit451.coiltransformations.sample"
         minSdkVersion(21)
-        targetSdkVersion(29)
+        targetSdkVersion(30)
         versionCode = 1
         versionName = "1.0.0"
         resConfigs("en")
@@ -28,6 +28,7 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+    buildToolsVersion = "30.0.2"
 }
 
 val lifecycleVersion = "2.0.0"
@@ -38,13 +39,13 @@ dependencies {
 
     implementation(kotlin("stdlib", KotlinCompilerVersion.VERSION))
 
-    implementation("androidx.appcompat:appcompat:1.1.0")
-    implementation("androidx.constraintlayout:constraintlayout:1.1.3")
-    implementation("androidx.core:core-ktx:1.2.0")
+    implementation("androidx.appcompat:appcompat:1.2.0")
+    implementation("androidx.constraintlayout:constraintlayout:2.0.2")
+    implementation("androidx.core:core-ktx:1.3.2")
     implementation("androidx.lifecycle:lifecycle-extensions:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-livedata:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion")
     implementation("androidx.recyclerview:recyclerview:1.1.0")
 
-    implementation("com.google.android.material:material:1.1.0")
+    implementation("com.google.android.material:material:1.2.1")
 }

--- a/sample/src/main/java/com/commit451/coiltransformations/sample/App.kt
+++ b/sample/src/main/java/com/commit451/coiltransformations/sample/App.kt
@@ -3,23 +3,24 @@
 package com.commit451.coiltransformations.sample
 
 import android.app.Application
+import android.util.Log
 import coil.Coil
 import coil.ImageLoader
-import coil.util.CoilLogger
+import coil.util.DebugLogger
 
 class App : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        CoilLogger.setEnabled(true)
-        Coil.setDefaultImageLoader(::buildDefaultImageLoader)
+        Coil.setImageLoader(::buildDefaultImageLoader)
     }
 
     private fun buildDefaultImageLoader(): ImageLoader {
-        return ImageLoader(this) {
-            availableMemoryPercentage(0.5)
-            bitmapPoolPercentage(0.5)
-            crossfade(true)
-        }
+        return ImageLoader.Builder(this)
+                .logger(DebugLogger(level = Log.DEBUG))
+                .availableMemoryPercentage(0.5)
+                .bitmapPoolPercentage(0.5)
+                .crossfade(true)
+                .build()
     }
 }

--- a/transformations-gpu/build.gradle.kts
+++ b/transformations-gpu/build.gradle.kts
@@ -5,24 +5,25 @@ plugins {
 }
 
 android {
-    compileSdkVersion(29)
+    compileSdkVersion(30)
     defaultConfig {
         minSdkVersion(14)
-        targetSdkVersion(29)
+        targetSdkVersion(30)
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+    buildToolsVersion = "30.0.2"
     libraryVariants.all {
         generateBuildConfigProvider?.configure { enabled = false }
     }
 }
 
 dependencies {
-    api("io.coil-kt:coil:0.9.5")
-    api("jp.co.cyberagent.android:gpuimage:2.0.3")
+    api("io.coil-kt:coil:0.13.0")
+    api("jp.co.cyberagent.android:gpuimage:2.1.0")
 }
 
 apply("https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.0.0/gradle-android-javadocs.gradle")

--- a/transformations-gpu/src/main/java/com/commit451/coiltransformations/gpu/GPUFilterTransformation.kt
+++ b/transformations-gpu/src/main/java/com/commit451/coiltransformations/gpu/GPUFilterTransformation.kt
@@ -2,7 +2,7 @@ package com.commit451.coiltransformations.gpu
 
 import android.content.Context
 import android.graphics.Bitmap
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.Size
 import coil.transform.Transformation
 import jp.co.cyberagent.android.gpuimage.GPUImage
@@ -26,7 +26,6 @@ abstract class GPUFilterTransformation(
         val gpuImage = GPUImage(context)
         gpuImage.setImage(input)
         gpuImage.setFilter(createFilter())
-        pool.put(input)
         return gpuImage.bitmapWithFilterApplied
     }
 }

--- a/transformations/build.gradle.kts
+++ b/transformations/build.gradle.kts
@@ -5,23 +5,25 @@ plugins {
 }
 
 android {
-    compileSdkVersion(29)
+    compileSdkVersion(30)
     defaultConfig {
         minSdkVersion(14)
-        targetSdkVersion(29)
+        targetSdkVersion(30)
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+    buildToolsVersion = "30.0.2"
     libraryVariants.all {
         generateBuildConfigProvider?.configure { enabled = false }
     }
 }
 
 dependencies {
-    api("io.coil-kt:coil:0.9.5")
+    api("io.coil-kt:coil:0.13.0")
+    api("androidx.core:core-ktx:1.3.2")
 }
 
 apply("https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle")

--- a/transformations/src/main/java/com/commit451/coiltransformations/ColorFilterTransformation.kt
+++ b/transformations/src/main/java/com/commit451/coiltransformations/ColorFilterTransformation.kt
@@ -2,7 +2,7 @@ package com.commit451.coiltransformations
 
 import android.graphics.*
 import androidx.annotation.ColorInt
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.Size
 import coil.transform.Transformation
 

--- a/transformations/src/main/java/com/commit451/coiltransformations/CropTransformation.kt
+++ b/transformations/src/main/java/com/commit451/coiltransformations/CropTransformation.kt
@@ -3,7 +3,7 @@ package com.commit451.coiltransformations
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.RectF
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.Size
 import coil.transform.Transformation
 import kotlin.math.max

--- a/transformations/src/main/java/com/commit451/coiltransformations/MaskTransformation.kt
+++ b/transformations/src/main/java/com/commit451/coiltransformations/MaskTransformation.kt
@@ -9,7 +9,7 @@ import android.graphics.drawable.Drawable
 import androidx.annotation.DrawableRes
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.applyCanvas
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.Size
 import coil.transform.Transformation
 

--- a/transformations/src/main/java/com/commit451/coiltransformations/SquareCropTransformation.kt
+++ b/transformations/src/main/java/com/commit451/coiltransformations/SquareCropTransformation.kt
@@ -1,7 +1,7 @@
 package com.commit451.coiltransformations
 
 import android.graphics.Bitmap
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.Size
 import coil.transform.Transformation
 import kotlin.math.max

--- a/transformations/src/main/java/com/commit451/coiltransformations/Util.kt
+++ b/transformations/src/main/java/com/commit451/coiltransformations/Util.kt
@@ -4,7 +4,7 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Matrix
 import android.graphics.Paint
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 
 /**
  * Internal utils used by various transformations


### PR DESCRIPTION
These are mostly library upgrades, with some minor api changes from newer versions of Coil. One major change to call out: in ```GPUFilterTransformation```, I'm no longer adding the input image to the ```BitmapPool```. Leaving it there, the images wouldn't load, and left an error message:
```
2020-10-06 21:19:24.931 13172-13172/com.commit451.coiltransformations.sample I/RealImageLoader: 🚨 Failed - 2131165286 - java.lang.IllegalArgumentException: bitmap is recycled
2020-10-06 21:19:25.048 13172-13172/com.commit451.coiltransformations.sample E/RealImageLoader: java.lang.IllegalArgumentException: bitmap is recycled
        at android.opengl.GLUtils.texImage2D(GLUtils.java:154)
        at jp.co.cyberagent.android.gpuimage.util.OpenGlUtils.loadTexture(OpenGlUtils.java:49)
        at jp.co.cyberagent.android.gpuimage.GPUImageRenderer$5.run(GPUImageRenderer.java:250)
        at jp.co.cyberagent.android.gpuimage.GPUImageRenderer.runAll(GPUImageRenderer.java:145)
        at jp.co.cyberagent.android.gpuimage.GPUImageRenderer.onDrawFrame(GPUImageRenderer.java:121)
        at jp.co.cyberagent.android.gpuimage.PixelBuffer.getBitmap(PixelBuffer.java:117)
        at jp.co.cyberagent.android.gpuimage.GPUImage.getBitmapWithFilterApplied(GPUImage.java:384)
        at jp.co.cyberagent.android.gpuimage.GPUImage.getBitmapWithFilterApplied(GPUImage.java:344)
        at jp.co.cyberagent.android.gpuimage.GPUImage.getBitmapWithFilterApplied(GPUImage.java:334)
        at com.commit451.coiltransformations.gpu.GPUFilterTransformation.transform$suspendImpl(GPUFilterTransformation.kt:30)
        at com.commit451.coiltransformations.gpu.GPUFilterTransformation.transform(Unknown Source:0)
        at coil.intercept.EngineInterceptor$intercept$2.invokeSuspend(EngineInterceptor.kt:480)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)

```

I tried fiddling with 
```
ImageLoader.Builder()
    availableMemoryPercentage(0.5)
    .bitmapPoolPercentage(0.5)
```
and also tried putting them at the top of the list, in hopes that it wouldn't have already been recycled on the very first transformation, but no such luck. That said, the sample app still performs very smoothly.
![transformation-performance](https://user-images.githubusercontent.com/22403330/95287455-cc9dd600-081a-11eb-8295-9725fcda0239.gif)

