### PR TITLE
Updated README for center-on-face

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ From the base library (`transformations`):
 - CropTransformation (top, center, bottom)
 - MaskTransformation
 - SquareCropTransformation
+- NoOpTransformation
 
 From the GPU library (`transformations-gpu`)
 - BrightnessFilterTransformation
@@ -51,6 +52,9 @@ From the GPU library (`transformations-gpu`)
 - SwirlFilterTransformation
 - ToonFilterTransformation
 - VignetteFilterTransformation
+
+From the face detection library (`transformations-center-on-face`)
+- CenterOnFaceTransformation
 
 ## Quick Start
 
@@ -122,6 +126,15 @@ Here, you can preview each of the type of filters.
 - VignetteFilterTransformation
 
 ![VignetteFilterTransformation](preview/images/vignette.png)
+
+- CenterOnFaceTransformation
+
+![CenterOnFaceTransformation](preview/images/COF-no-op-and-zero.png)
+
+![CenterOnFaceTransformation](preview/images/COF-20-and-40.png)
+
+![CenterOnFaceTransformation](preview/images/COF-80-and-100.png)
+
 
 ## Thanks
 Inspired by [Glide Transformations](https://github.com/wasabeef/glide-transformations) by [wasabeef](https://github.com/wasabeef). Thanks of course to [Coil](https://github.com/coil-kt/coil) contributors for making a great image loading library.


### PR DESCRIPTION
Updated README for the center-on-face transformation. New images in the README aren't the same width, not sure if that's a dealbreaker. Your call. Images attached.
<img width="761" alt="Screen Shot 2020-10-18 at 11 25 12 PM" src="https://user-images.githubusercontent.com/22403330/96525886-f995b400-1230-11eb-8f5e-2d731f44b790.png">
